### PR TITLE
chore: ignore generated media files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Generated media
+*.mp3
+*.wav
+*.mp4
+*.png
+*.jpg
+__pycache__/


### PR DESCRIPTION
## Summary
- ignore generated media files and __pycache__ to prevent binaries from being tracked

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bddb3d219883219ebf8d89130eddf8